### PR TITLE
Use @staticmethod, add mutually exclusive flags

### DIFF
--- a/yts/yts.py
+++ b/yts/yts.py
@@ -141,12 +141,10 @@ class YTS:
         )
         return {movie_title: rating}
 
-    
     # Check if argument format is present in extracted formats
     @staticmethod
     def check_format_availability(format, formats) -> bool:
         return format in formats
-
 
     # Execute Transmission-gtk with the downloaded torrent
     @staticmethod

--- a/yts/yts.py
+++ b/yts/yts.py
@@ -8,6 +8,21 @@ import sys
 import os
 import subprocess
 
+
+# Make request to the given url
+# Returns the response object
+# TODO give a user-friendly error
+def make_request(url):
+    try:
+        res = requests.get(url)
+        res.raise_for_status()
+    except requests.exceptions.RequestException as err:
+        print(err)
+        sys.exit()
+
+    return res
+
+
 # YTS CLASS
 class YTS:
     """ provides an API for downloading yts yifi movies. """
@@ -18,7 +33,8 @@ class YTS:
 
     # Gets the movie title from the arguments
     # Returns a string (eg: the-nun-2018)
-    def get_movie_title(self, movie_name, movie_year) -> str:
+    @staticmethod
+    def get_movie_title(movie_name, movie_year) -> str:
         name = movie_name.lower().split()
         year = movie_year # TODO check if valid year
         return "-".join(name) + "-" + year
@@ -27,12 +43,13 @@ class YTS:
     # Returns a response object
     def get_movie_page(self, movie_title):
         url = self.url+"movie/"+movie_title
-        movie_page = self.make_request(url)
+        movie_page = make_request(url)
         return movie_page
 
     # Get the movie formats from the movie page
     # Returns a dictionary of formats with their torrent urls as values
-    def extract_formats(self, movie_page) -> dict:
+    @staticmethod
+    def extract_formats(movie_page) -> dict:
         movie_formats = (
             bs4.BeautifulSoup(movie_page.text, "lxml")
             .select("p[class='hidden-xs hidden-sm']")[0]
@@ -45,9 +62,10 @@ class YTS:
 
     # Download and save movie torrent file to current folder
     # Returns torrent name (eg: the-nun-2018.torrent)
-    def get_torrent(self, movie_title, torrent_url):
-        res = self.make_request(torrent_url)
-        torrent_name = movie_title+".torrent"
+    @staticmethod
+    def get_torrent(movie_title, torrent_url):
+        res = make_request(torrent_url)
+        torrent_name = movie_title + ".torrent"
         if not os.path.isfile(torrent_name):
             with open(torrent_name, "wb") as torrent_file:
                 torrent_file.write(res.content)
@@ -58,8 +76,8 @@ class YTS:
 
     # Gets the popular downloads from the homepage
     # Returns a dictionary with movie title and rating
-    def get_popluar_downloads(self) -> dict:
-        res = self.make_request(self.url)
+    def get_popular_downloads(self) -> dict:
+        res = make_request(self.url)
         pop_movies_dict = {}
         pop_movies = (
             bs4.BeautifulSoup(res.text, "lxml")
@@ -86,31 +104,25 @@ class YTS:
             movie_data = movie.select("a > figure")[0]
             query_dict.update(self.extract_movie_data(movie_data))
         return query_dict
+    
+    # Check if argument format is present in extracted formats
+    @staticmethod
+    def check_format_availability(format, formats) -> bool:
+        return format in formats
 
+    def get_movie_data(self, name, year):
+        title = self.get_movie_title(name, year)
+        page = self.get_movie_page(title)
+        formats = self.extract_formats(page)
+        return title, formats
 
     ### UTIL FUNCTIONS ###
-
-    # Make request to the given url
-    # Returns the response object
-    # TODO give a user-friendly error
-    def make_request(self, url):
-        try:
-            res = requests.get(url)
-            res.raise_for_status()
-        except requests.exceptions.RequestException as err:
-            print(err)
-            sys.exit()
-
-        return res
-
-    # Check if argument format is present in extracted formats
-    def check_format_availability(self, format, formats) -> bool:
-        return format in formats
 
     # Used by get_popular_downloads and search_movies
     # extracts movie title with its rating
     # Returns a dictionary (eg {'the-nun (2018)': '5.3 / 10'})
-    def extract_movie_data(self, movie_data) -> dict:
+    @staticmethod
+    def extract_movie_data(movie_data) -> dict:
         movie_title = (
             movie_data
             .select("img")[0]["alt"]
@@ -124,60 +136,63 @@ class YTS:
         )
         return {movie_title: rating}
 
+
     # Execute Transmission-gtk with the downloaded torrent
-    def execute_transmission(self, torrent_name):
-        command = f"transmission-gtk {torrent_name}"
-        command_list = command.split()
-        subprocess.Popen(command_list)
+    @staticmethod
+    def execute_transmission(torrent_name):
+        subprocess.Popen(["transmission-gtk", torrent_name])
 
     # Utitility method to print available formats
     # Param: return of extract_format method
-    def print_formats(self, formats):
+    @staticmethod
+    def print_formats(formats=None, name=None, year=None):
+        if formats is None:
+            formats = yts.get_movie_data(name, year)[1]
+
         print("Available In:")
         for key in formats.keys():
             print("\t", key)
 
-
 # TODO design a better cli usage
 # Handle CLI arguments Class
 class Arguments:
-
     # Initialize arguments
     def __init__(self):
         self.arguments = self.get_cli_args()
-        self.check_one_flag_usage()
 
     # Handles CLI arguments
     # Returns a dictionary of the arguments
     # Only one flag is to be applied at a time
-    def get_cli_args(self) -> dict:
+    @staticmethod
+    def get_cli_args() -> dict:
         parser = argparse.ArgumentParser(prog="yts",
                                          description="Downloads YTS movie torrents.",
                                          allow_abbrev=False)
 
+        flags = parser.add_mutually_exclusive_group("Select one option for downloading.", required=True)
         # Add available movie formats argument
-        parser.add_argument("-f",
+        flags.add_argument("-f",
                             nargs=2,
                             metavar=("MOVIE", "YEAR"),
                             action="store",
                             help="shows the available movie formats")
 
         # Add download movie torrent argument
-        parser.add_argument("-d",
+        flags.add_argument("-d",
                             nargs=3,
                             metavar=("MOVIE", "YEAR", "FORMAT"),
                             action="store",
                             help="downloads movie torrent in the given format")
 
         # Add search movie argument
-        parser.add_argument("-s",
+        flags.add_argument("-s",
                             nargs=1,
                             metavar="MOVIE",
                             action="store",
                             help="search movies in yts")
 
         # Add popular movies argument
-        parser.add_argument("-p",
+        flags.add_argument("-p",
                             action="store_true",
                             help="shows popular downloads")
 
@@ -185,85 +200,36 @@ class Arguments:
         arguments_dict = vars(parser.parse_args())
         return arguments_dict
 
-    # Get -s search query argument
-    # Returns a string
-    def get_search_arguments(self) -> str:
-        if self.arguments["s"] == None:
-            sys.exit("Provide a search query")
-        return self.arguments["s"]
-
-    # Get -f arguments
-    # Returns a list of (movie-name, year)
-    def get_format_arguments(self) -> list:
-        if self.arguments["f"] == None:
-            sys.exit("Use the -f flag")
-        elif len(self.arguments["f"]) != 2:
-            sys.exit("Provide a Movie name and year")
-        return self.arguments["f"]
-
-    # Get -d arguments
-    # Returns a list of (movie-name, year, format)
-    def get_download_arguments(self) -> list:
-        if self.arguments["d"] == None:
-            sys.exit("Use the -d flag")
-        elif len(self.arguments["d"]) != 3:
-            sys.exit("Provide a Movie name, year and format")
-        return self.arguments["d"]
-
-    # Check for only one flag usage
-    def check_one_flag_usage(self) -> None:
-        flags_applied = self.number_of_flags(self.arguments)
-
-        # create an error and exit
-        if flags_applied == 0:
-            sys.exit("Error: Check Usage using -h")
-        elif flags_applied > 1:
-            sys.exit("Error: Only one flag is applicable")
-
-    # Returns an int of number of flags set
-    def number_of_flags(self, arguments_dict) -> int:
-        # Convert arguments to 0 if not present or False
-        # and to 1 if present or True
-        arguments_dict_int = []
-        for value in arguments_dict.values():
-            if value in (False, None):
-                arguments_dict_int.append(0)
-            else:
-                arguments_dict_int.append(1)
-
-        return sum(arguments_dict_int)
+    def __getitem__(self, arg):
+        return self.arguments[arg]
 
 
 def main():
     yts = YTS("https://yts.mx/")
-    args = Arguments()
+    args = Arguments.get_cli_args()
 
     # Handle arguments
-    if args.arguments["p"]:
-        pop_movies = yts.get_popluar_downloads()
+    if args["p"]:
+        pop_movies = yts.get_popular_downloads()
         if pop_movies:
             print("Popular Downloads:")
             for movie, rating in pop_movies.items():
                 print(f"\t{movie} {rating}")
 
-    elif args.arguments["s"]:
-        query = args.get_search_arguments()
-        search_query_res = yts.search_movies(query)
+    elif args["s"]:
+        results = yts.search_movies(args["s"])
         print("Movies Found:")
-        for movie, rating in search_query_res.items():
+        for movie, rating in results.items():
             print(f"\t{movie} {rating}")
-    elif args.arguments["f"]:
-        name, year = args.get_format_arguments()
-        title = yts.get_movie_title(name, year)
-        page = yts.get_movie_page(title)
-        formats = yts.extract_formats(page)
-        yts.print_formats(formats)
-    elif args.arguments["d"]:
-        name, year, movie_format = args.get_download_arguments()
-        title = yts.get_movie_title(name, year)
-        page = yts.get_movie_page(title)
-        formats = yts.extract_formats(page)
-        if yts.check_format_availability(movie_format, formats):
+
+    elif args["f"]:
+        name, year = args["f"]
+        yts.print_formats(name=name, year=year)
+
+    elif args["d"]:
+        name, year, movie_format = args["d"]
+        title, formats = yts.get_movie_data(name, year)
+        if movie_format in formats:
             torrent_url = formats[movie_format]
             torrent_name = yts.get_torrent(title, torrent_url)
             if not torrent_name:


### PR DESCRIPTION
Instead of == None, it is more idiomatic to use is None - this is good practice in general. 

If you specify the number of args for argparse, argparse will automatically create a list of the specified size - there is no need to check the length of the output. You can also use parser.add_mutually_exclusive_group() to create a mutually exclusive group, of which only one option can be specified, which helps simplify your Arguments class a lot.

If you use a number of methods together, such as getting the title, page, and format of a given movie, it may be better to just put them into a single function - the user probably doesn't care about the page, which is raw data, but is interested in knowing the title and available formats of their movie.

For functions that should belong inside a class but don't need the classes' fields (eg. self is never used), it's often a good idea to use @staticmethod to enforce this - it helps avoid potential bugs from modifying the class, and it allows the method to be used as a class level method - eg. YTS.static_method(arg1, arg2), without having to instantiate a YTS object.

I also made use of __getitem__ for Arguments, which defines how Arguments["a"] behaves - so we can now directly call args["p"] without having to specify args.arguments["p"], which looks strange if it's already an Arguments class. Alternatively, by using @staticmethod, we could also call Arguments.get_cli_arguments() and avoid creating an Argument object altogether.